### PR TITLE
Adjust lastVisited updates for log outcomes

### DIFF
--- a/index.html
+++ b/index.html
@@ -605,11 +605,14 @@
       await addDoc(userCol('visits'), visit);
       const ref = doc(db, 'users', currentUser.uid, 'elders', elderId);
       const isVisited = (outcome === 'Visited' || outcome === 'Scheduled');
-      await updateDoc(ref, {
-        lastVisited: isVisited ? new Date(dateStr) : serverTimestamp(),
+      const update = {
         lastContacted: serverTimestamp(),
         attemptsSinceLastVisit: isVisited ? 0 : increment(1)
-      });
+      };
+      if (isVisited) {
+        update.lastVisited = new Date(dateStr);
+      }
+      await updateDoc(ref, update);
       q('logNotes').value='';
       alert('Saved.');
     };


### PR DESCRIPTION
## Summary
- update the log visit workflow to only include `lastVisited` when an outcome reflects an actual visit
- leave the previous visit timestamp untouched for outcomes such as "No answer" while still tracking contact attempts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb81659fac83268b78e726e75a4758