### PR TITLE
Ensure merged elders stay active if any source active

### DIFF
--- a/index.html
+++ b/index.html
@@ -847,7 +847,8 @@
             lastContacted: maxDate(keep.lastContacted, dup.lastContacted) || keep.lastContacted || dup.lastContacted || null,
             attemptsSinceLastVisit: Math.max(keep.attemptsSinceLastVisit||0, dup.attemptsSinceLastVisit||0),
             doNotText: !!(keep.doNotText || dup.doNotText),
-            active: (keep.active!==false && dup.active!==false)
+            // Keep the merged elder active if any source record is still active.
+            active: (keep.active!==false || dup.active!==false)
           };
           await updateDoc(doc(db,'users',uid,'elders',keep.id), merged);
           await deleteDoc(doc(db,'users',uid,'elders',dup.id));


### PR DESCRIPTION
## Summary
- update duplicate merge logic so merged elders remain active if any source record is active
- add a comment clarifying the intent of the active field merge

## Testing
- node -e "const mergeActive=(a,b)=>((a!==false)||(b!==false)); console.log('true+false ->', mergeActive(true,false)); console.log('false+false ->', mergeActive(false,false)); console.log('undefined+false ->', mergeActive(undefined,false));"


------
https://chatgpt.com/codex/tasks/task_e_68cb8167d500832686cddb487d041e99