### PR TITLE
Improve mobile layout for elders actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,8 @@
     .thbtn span { margin-left:.25rem; color:#6b7280; }
     tr.inactive { opacity:.55; }
     td.namecell { display:flex; align-items:center; gap:.5rem; font-weight:600; }
+    td.actions-cell { vertical-align:top; }
+    .actions-cell .action-buttons { display:flex; gap:.35rem; flex-wrap:wrap; }
     #authBox { display:flex; gap:.5rem; align-items:center; margin-left:auto; }
     #currentUser { max-width:45vw; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:#374151; }
 
@@ -55,8 +57,8 @@
       #view-elders table thead { display:none; }
       #view-elders table, #view-elders tbody, #view-elders tr, #view-elders td { display:block; width:100%; }
       #view-elders tbody tr { background:#fff; border:1px solid var(--line); border-radius:12px; padding:.5rem .75rem; margin:.75rem 0; }
-      #view-elders tbody td { display:flex; justify-content:space-between; align-items:center; border:0; padding:.35rem 0; }
-      #view-elders tbody td::before { content:attr(data-label); font-weight:600; color:#6b7280; margin-right:1rem; }
+      #view-elders tbody td { display:flex; flex-direction:column; align-items:flex-start; gap:.25rem; border:0; padding:.35rem 0; }
+      #view-elders tbody td::before { content:attr(data-label); font-weight:600; color:#6b7280; margin:0 0 .15rem; display:block; }
       #view-elders tbody td.namecell { font-size:1rem; padding-bottom:.4rem; }
       #view-elders tbody td.namecell::before { content:'Name'; }
       #currentUser { max-width:60vw; }
@@ -551,12 +553,14 @@
           <td data-label="Attempts">${e.attemptsSinceLastVisit||0}</td>
           <td data-label="Asked">${askedCell}</td>
           <td data-label="Status">${statusPill}</td>
-          <td data-label="Actions" style="display:flex; gap:.35rem; flex-wrap:wrap">
-            <button class="btn outline" onclick="textAndTrack('${e.id}')">Text</button>
-            <button class="btn" onclick="quickLogVisit('${e.id}')">Log</button>
-            <button class="btn outline" onclick="editElder('${e.id}')">Edit</button>
-            <button class="btn outline" onclick="adjustMenu('${e.id}')">Adjust…</button>
-            <button class="btn ${inactive?'outline danger':'danger'}" onclick="toggleArchive('${e.id}', ${inactive})">${archiveLabel}</button>
+          <td class="actions-cell" data-label="Actions">
+            <div class="action-buttons">
+              <button class="btn outline" onclick="textAndTrack('${e.id}')">Text</button>
+              <button class="btn" onclick="quickLogVisit('${e.id}')">Log</button>
+              <button class="btn outline" onclick="editElder('${e.id}')">Edit</button>
+              <button class="btn outline" onclick="adjustMenu('${e.id}')">Adjust…</button>
+              <button class="btn ${inactive?'outline danger':'danger'}" onclick="toggleArchive('${e.id}', ${inactive})">${archiveLabel}</button>
+            </div>
           </td>
         </tr>`;
       }).join('');

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     tr.inactive { opacity:.55; }
     td.namecell { display:flex; align-items:center; gap:.5rem; font-weight:600; }
     td.actions-cell { vertical-align:top; }
-    .actions-cell .action-buttons { display:flex; gap:.35rem; flex-wrap:wrap; }
+    .actions-cell .action-buttons { display:flex; gap:.35rem; flex-wrap:wrap; align-items:center; }
     #authBox { display:flex; gap:.5rem; align-items:center; margin-left:auto; }
     #currentUser { max-width:45vw; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:#374151; }
 
@@ -59,6 +59,8 @@
       #view-elders tbody tr { background:#fff; border:1px solid var(--line); border-radius:12px; padding:.5rem .75rem; margin:.75rem 0; }
       #view-elders tbody td { display:flex; flex-direction:column; align-items:flex-start; gap:.25rem; border:0; padding:.35rem 0; }
       #view-elders tbody td::before { content:attr(data-label); font-weight:600; color:#6b7280; margin:0 0 .15rem; display:block; }
+      #view-elders tbody td.actions-cell { gap:.45rem; }
+      #view-elders tbody td.actions-cell .action-buttons { justify-content:flex-start; width:100%; }
       #view-elders tbody td.namecell { font-size:1rem; padding-bottom:.4rem; }
       #view-elders tbody td.namecell::before { content:'Name'; }
       #currentUser { max-width:60vw; }

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       #view-elders tbody td { display:flex; flex-direction:column; align-items:flex-start; gap:.25rem; border:0; padding:.35rem 0; }
       #view-elders tbody td::before { content:attr(data-label); font-weight:600; color:#6b7280; margin:0 0 .15rem; display:block; }
       #view-elders tbody td.actions-cell { gap:.45rem; }
-      #view-elders tbody td.actions-cell .action-buttons { justify-content:flex-start; width:100%; }
+      #view-elders tbody td.actions-cell .action-buttons { justify-content:flex-start; align-items:flex-start; width:100%; }
       #view-elders tbody td.namecell { font-size:1rem; padding-bottom:.4rem; }
       #view-elders tbody td.namecell::before { content:'Name'; }
       #currentUser { max-width:60vw; }


### PR DESCRIPTION
## Summary
- stack directory cell labels above their content on mobile for better readability
- add a dedicated action-buttons wrapper so action controls stay grouped beneath the label
- ensure actions cell buttons retain their flexible row layout on larger screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc5885989c8326832ceecda91dedb8