### PR TITLE
Sanitize elder first name for SMS

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,8 +633,11 @@
         attemptsSinceLastVisit: increment(1)
       });
 
-      const name = (e.preferredName || e.lastName || 'there');
-      const smsUrl = `sms:+1${cleanPhone(e.phone)}?&body=${encodeURIComponent(smsBodyFor(name))}`;
+      const rawName = (e.preferredName ? e.preferredName.trim() : '')
+        || (e.lastName ? e.lastName.trim() : '')
+        || 'there';
+      const firstName = rawName.split(/\s+/)[0] || 'there';
+      const smsUrl = `sms:+1${cleanPhone(e.phone)}?&body=${encodeURIComponent(smsBodyFor(firstName))}`;
       setTimeout(()=>{ window.location.href = smsUrl; }, 100);
     }, 'Unable to send that text. Please check your connection and try again.');
 


### PR DESCRIPTION
## Summary
- trim and sanitize the elder's preferred name when preparing an SMS
- ensure only the first whitespace-delimited token is passed to `smsBodyFor`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cdd92203c883268216d3d8b10f04c5