### PR TITLE
Add visit history previews and modal to elders directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,12 @@
       #view-elders tbody td.actions .btn { flex:1 1 calc(50% - .3rem); min-width:7rem; }
       #view-elders tbody td.actions .btn.danger { flex-basis:100%; }
       #currentUser { max-width:60vw; }
+      #view-elders tbody tr.history-row { border:none; background:transparent; padding:0; margin:0; display:none !important; }
+      #view-elders tbody tr.history-row.open { display:block !important; padding:0; }
+      #view-elders tbody tr.history-row.open td { padding:0; }
+      #view-elders tbody tr.history-row .history-panel { margin-top:.35rem; }
+      .history-panel { border-radius:10px; }
+      .modal { width:100%; max-width:100%; }
     }
 
     /* “two-up” area on Next Up */
@@ -101,6 +107,39 @@
     .confirm-message { font-size:.95rem; color:#1f2937; }
     .confirm-buttons { display:flex; justify-content:flex-end; gap:.5rem; flex-wrap:wrap; }
     .confirm-overlay button { min-width:0; }
+    .history-row { background:transparent; border:none; }
+    .history-row td { padding:0; border:0; }
+    .history-row:not(.open) { display:none; }
+    .history-row.open { display:table-row; }
+    .history-panel { background:#f9fafb; border-radius:12px; padding:1rem; margin-top:.5rem; border:1px solid var(--line); }
+    .history-panel-header { display:flex; align-items:center; justify-content:space-between; gap:.75rem; margin-bottom:.75rem; }
+    .history-panel-title { font-weight:600; color:#1f2937; }
+    .history-panel-range { font-size:.85rem; color:var(--muted); }
+    .history-list { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:.75rem; }
+    .history-item { display:grid; gap:.25rem; }
+    .history-date { font-weight:600; color:#111827; display:flex; gap:.5rem; align-items:baseline; flex-wrap:wrap; }
+    .history-relative { font-size:.8rem; color:var(--muted); }
+    .history-meta { font-size:.9rem; color:#374151; }
+    .history-notes { font-size:.9rem; color:#4b5563; white-space:pre-wrap; }
+    .history-empty { font-size:.9rem; color:var(--muted); }
+    .modal-overlay { position:fixed; inset:0; background:rgba(15,23,42,.45); display:flex; align-items:center; justify-content:center;
+      padding:1rem; z-index:45; opacity:0; pointer-events:none; transition:opacity .2s ease; }
+    .modal-overlay.open { opacity:1; pointer-events:auto; }
+    .modal { background:#fff; width:min(520px,100%); max-height:90vh; border-radius:16px; box-shadow:0 22px 45px rgba(15,23,42,.25);
+      border:1px solid rgba(15,23,42,.08); display:flex; flex-direction:column; }
+    .modal:focus { outline:none; }
+    .modal-header { display:flex; align-items:center; justify-content:space-between; padding:1.1rem 1.25rem; border-bottom:1px solid var(--line); }
+    .modal-title { font-size:1.05rem; font-weight:600; margin:0; }
+    .modal-close { background:none; border:0; color:#6b7280; font-size:1.3rem; line-height:1; cursor:pointer; border-radius:8px; padding:.25rem; }
+    .modal-close:focus-visible { outline:2px solid var(--brand); outline-offset:2px; }
+    .modal-body { padding:1rem 1.25rem; overflow-y:auto; display:flex; flex-direction:column; gap:.85rem; }
+    .modal-footer { padding:.85rem 1.25rem 1.1rem; border-top:1px solid var(--line); display:flex; align-items:center; justify-content:space-between; gap:.75rem; flex-wrap:wrap; }
+    .history-modal-page { font-size:.85rem; color:var(--muted); }
+    .history-modal-list { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:.85rem; }
+    .history-modal-item { display:grid; gap:.3rem; }
+    .history-modal-item .history-date { font-size:.95rem; }
+    .history-modal-empty { font-size:.95rem; color:var(--muted); }
+    .history-modal-controls { display:flex; gap:.5rem; flex-wrap:wrap; }
   </style>
 </head>
 <body>
@@ -111,6 +150,22 @@
       <div class="confirm-buttons">
         <button type="button" class="btn outline" data-cancel>Cancel</button>
         <button type="button" class="btn" data-confirm>Confirm</button>
+      </div>
+    </div>
+  </div>
+  <div id="visitHistoryOverlay" class="modal-overlay" aria-hidden="true">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="visitHistoryTitle" tabindex="-1">
+      <div class="modal-header">
+        <h2 id="visitHistoryTitle" class="modal-title">Visit history</h2>
+        <button type="button" class="modal-close" aria-label="Close visit history" onclick="closeVisitHistoryModal()">×</button>
+      </div>
+      <div id="visitHistoryBody" class="modal-body"></div>
+      <div class="modal-footer">
+        <div class="history-modal-page" id="visitHistoryPage"></div>
+        <div class="history-modal-controls">
+          <button type="button" class="btn outline" id="visitHistoryPrev" onclick="changeVisitHistoryPage(-1)">Previous</button>
+          <button type="button" class="btn outline" id="visitHistoryNext" onclick="changeVisitHistoryPage(1)">Next</button>
+        </div>
       </div>
     </div>
   </div>
@@ -169,6 +224,12 @@
           <option value="visited">Last visited</option>
           <option value="attempts">Attempts (recent first)</option>
           <option value="phone">Phone</option>
+        </select>
+        <select id="visitRange" class="input" title="Visit history range">
+          <option value="90">Recent 90 days</option>
+          <option value="180">Recent 6 months</option>
+          <option value="365">Recent year</option>
+          <option value="all">All visits</option>
         </select>
         <button class="btn outline" onclick="addElderPrompt()">Quick add</button>
         <label class="toggle-inactive">
@@ -281,6 +342,10 @@
     let confirmResolver = null;
     let confirmActive = false;
     let confirmLastFocus = null;
+    const expandedHistoryPanels = new Set();
+    let currentVisitRange = '90';
+    const visitHistoryModalState = { open: false, elderId: null, page: 0, pageSize: 10 };
+    let visitHistoryLastFocus = null;
 
     const hideToastElement = (toast) => {
       if (!toast) return;
@@ -421,6 +486,82 @@
     const nowMs = ()=> Date.now();
     const daysBetween = (ms)=> Math.floor((nowMs()-ms)/86400000);
     const monthsAgo = (n)=>{ const d=new Date(); d.setMonth(d.getMonth()-n); d.setHours(0,0,0,0); return d; };
+    const visitRangeOptions = {
+      '90': { days: 90, label: 'Last 90 days' },
+      '180': { days: 180, label: 'Last 6 months' },
+      '365': { days: 365, label: 'Last 12 months' },
+      'all': { days: Infinity, label: 'All recorded visits' }
+    };
+
+    const visitDateToMs = (value)=>{
+      if (!value) return 0;
+      if (typeof value === 'number' && Number.isFinite(value)) return value;
+      if (value instanceof Date) return value.getTime();
+      if (typeof value === 'string'){
+        const parsed = Date.parse(value);
+        if (!Number.isNaN(parsed)) return parsed;
+      }
+      if (value?.toDate){
+        const d = value.toDate();
+        if (d instanceof Date && !Number.isNaN(d.getTime())) return d.getTime();
+      }
+      return 0;
+    };
+    const visitSortMs = (visit)=> visitDateToMs(visit?.visitDate) || asMs(visit?.createdAt) || 0;
+    const formatVisitDate = (value)=>{
+      if (!value) return '—';
+      if (value instanceof Date) return value.toLocaleDateString();
+      if (typeof value === 'string'){
+        const parsed = Date.parse(value);
+        if (!Number.isNaN(parsed)) return new Date(parsed).toLocaleDateString();
+      }
+      if (value?.toDate){
+        const d = value.toDate();
+        if (d instanceof Date) return d.toLocaleDateString();
+      }
+      return fmtDate(value);
+    };
+    const relativeTimeFromMs = (ms)=>{
+      if (!ms) return '';
+      const days = daysBetween(ms);
+      if (days <= 0) return 'today';
+      if (days === 1) return 'yesterday';
+      if (days < 7) return `${days} day${days===1?'':'s'} ago`;
+      if (days < 30){
+        const weeks = Math.round(days / 7);
+        return `${weeks} wk${weeks===1?'':'s'} ago`;
+      }
+      if (days < 365){
+        const months = Math.round(days / 30);
+        return `${months} mo ago`;
+      }
+      const years = Math.round(days / 365);
+      return `${years} yr${years===1?'':'s'} ago`;
+    };
+    const escapeMultiline = (value)=> escapeHtml(value).replace(/\r?\n/g,'<br>');
+    const renderHistoryItem = (visit, itemClass = 'history-item')=>{
+      const dateHtml = escapeHtml(formatVisitDate(visit.visitDate));
+      const relativeText = relativeTimeFromMs(visit._ms);
+      const relativeHtml = relativeText ? ` <span class="history-relative">${escapeHtml(relativeText)}</span>` : '';
+      const metaParts = [];
+      if (visit.outcome) metaParts.push(escapeHtml(visit.outcome));
+      if (visit.visitors) metaParts.push(escapeHtml(visit.visitors));
+      const metaHtml = metaParts.length ? `<div class="history-meta">${metaParts.join(' • ')}</div>` : '';
+      const notesHtml = visit.notes ? `<div class="history-notes">${escapeMultiline(visit.notes)}</div>` : '';
+      return `<li class="${itemClass}"><div class="history-date">${dateHtml}${relativeHtml}</div>${metaHtml}${notesHtml}</li>`;
+    };
+    const getVisitsForElder = (elderId)=> visits
+      .filter(v => v.elderId === elderId)
+      .map(v => ({ ...v, _ms: visitSortMs(v) }))
+      .sort((a,b)=> (b._ms - a._ms) || (asMs(b.createdAt) - asMs(a.createdAt)));
+    const getRangeLabel = ()=> visitRangeOptions[currentVisitRange]?.label || 'Recent visits';
+    const visitsInRange = (elderId)=>{
+      const list = getVisitsForElder(elderId);
+      const opt = visitRangeOptions[currentVisitRange];
+      if (!opt || !Number.isFinite(opt.days) || opt.days === Infinity) return list;
+      const cutoff = Date.now() - opt.days * 86400000;
+      return list.filter(v => (v._ms || 0) >= cutoff);
+    };
 
     function getMonday(d=new Date()){
       const x = new Date(d); const day = x.getDay(); // 0=Sun
@@ -499,7 +640,15 @@
     onAuthStateChanged(auth, (user)=>{
       currentUser = user;
       updateAuthUI(user);
-      if (user) subscribeData(); else { unsubscribeData(); elders.clear(); visits.length=0; schedules.length=0; renderAll(); }
+      if (user) subscribeData(); else {
+        unsubscribeData();
+        elders.clear();
+        visits.length = 0;
+        schedules.length = 0;
+        visitHistoryModalState.open = false;
+        visitHistoryModalState.elderId = null;
+        renderAll();
+      }
     });
     window.signIn = runAction(async ()=>{
       await signInWithEmailAndPassword(auth, q('email').value.trim(), q('password').value.trim());
@@ -546,6 +695,15 @@
         sortDir = (sortBy==='visited' || sortBy==='attempts') ? 'desc' : 'asc';
         renderElders();
       });
+      const rangeSelect = q('visitRange');
+      if (rangeSelect){
+        rangeSelect.value = currentVisitRange;
+        rangeSelect.addEventListener('change', e=>{
+          currentVisitRange = e.target.value;
+          renderElders();
+          renderVisitHistoryModal();
+        });
+      }
     };
 
     /* ---------- Queue settings (rolling 12m + texting cooldown) ---------- */
@@ -597,7 +755,7 @@
       if (name==='log') fillLogSelect();
       updateSortArrows(); updateCounters(); window.scrollTo({top:0, behavior:'smooth'});
     };
-    function renderAll(){ renderNext(); renderElders(); fillLogSelect(); updateSortArrows(); updateCounters(); }
+    function renderAll(){ renderNext(); renderElders(); fillLogSelect(); updateSortArrows(); updateCounters(); renderVisitHistoryModal(); }
 
     // --- Next Up (cards) + “recent texts” + “this week” ---
     function renderNext(){
@@ -712,6 +870,45 @@
     }
 
     /* ---------- Directory ---------- */
+    function renderHistoryPreview(elder, expanded){
+      if (!expanded || !elder?.id) return '';
+      const allVisits = getVisitsForElder(elder.id);
+      const rangedVisits = visitsInRange(elder.id);
+      const previewVisits = rangedVisits.slice(0, 3);
+      const label = getRangeLabel();
+      const labelHtml = escapeHtml(label);
+      const showMore = rangedVisits.length > previewVisits.length;
+      let bodyHtml = '';
+
+      if (!previewVisits.length){
+        const message = allVisits.length
+          ? `No visits in ${label}. Try widening the range.`
+          : 'No visits recorded yet.';
+        bodyHtml = `<div class="history-empty">${escapeHtml(message)}</div>`;
+      } else {
+        const itemsHtml = previewVisits.map(v=> renderHistoryItem(v)).join('');
+        const moreHtml = showMore ? `<div class="history-empty">Showing ${previewVisits.length} of ${rangedVisits.length} visits in range.</div>` : '';
+        bodyHtml = `<ul class="history-list">${itemsHtml}</ul>${moreHtml}`;
+      }
+
+      const totalHtml = (!previewVisits.length && allVisits.length)
+        ? `<div class="history-empty">Total recorded visits: ${allVisits.length}</div>`
+        : '';
+
+      return `
+        <div class="history-panel">
+          <div class="history-panel-header">
+            <div>
+              <div class="history-panel-title">Recent visits</div>
+              <div class="history-panel-range">${labelHtml}</div>
+            </div>
+            <button type="button" class="btn outline" onclick="openVisitHistoryModal('${elder.id}')">Full history</button>
+          </div>
+          ${bodyHtml}
+          ${totalHtml}
+        </div>`;
+    }
+
     window.renderElders = renderElders;
     function renderElders(){
       const tb = q('eldersTbody');
@@ -746,8 +943,13 @@
         const nameHtml = escapeHtml([e.preferredName, e.lastName].filter(Boolean).join(' ').trim());
         const visitedHtml = escapeHtml(fmtDate(e.lastVisited));
         const attemptsHtml = escapeHtml(String(e.attemptsSinceLastVisit||0));
+        const expanded = expandedHistoryPanels.has(e.id);
+        const historyLabel = expanded ? 'Hide visits' : 'Show visits';
+        const historyLabelHtml = escapeHtml(historyLabel);
+        const panelHtml = renderHistoryPreview(e, expanded);
+        const rowClasses = [inactive?'inactive':''].filter(Boolean).join(' ');
 
-        return `<tr class="${inactive?'inactive':''}">
+        return `<tr class="${rowClasses}">
           <td class="namecell" data-label="Name">${nameHtml}</td>
           <td data-label="Phone">${telLink || ''}</td>
           <td data-label="Last visited">${visitedHtml}</td>
@@ -759,9 +961,10 @@
             <button class="btn" onclick="quickLogVisit('${e.id}')">Log</button>
             <button class="btn outline" onclick="editElder('${e.id}')">Edit</button>
             <button class="btn outline" onclick="adjustMenu('${e.id}')">Adjust…</button>
+            <button class="btn light" onclick="toggleHistoryPanel('${e.id}')">${historyLabelHtml}</button>
             <button class="btn ${inactive?'outline danger':'danger'}" onclick="toggleArchive('${e.id}', ${inactive})">${archiveLabelHtml}</button>
           </td>
-        </tr>`;
+        </tr><tr class="history-row ${expanded?'open':''}"><td colspan="7">${panelHtml}</td></tr>`;
       }).join('');
 
       updateSortArrows(); updateCounters();
@@ -777,6 +980,131 @@
       }).join('');
       if (!q('logDate').value) q('logDate').valueAsDate = new Date();
     }
+
+    function renderVisitHistoryModal(){
+      const overlay = q('visitHistoryOverlay');
+      const body = q('visitHistoryBody');
+      const pageEl = q('visitHistoryPage');
+      const prevBtn = q('visitHistoryPrev');
+      const nextBtn = q('visitHistoryNext');
+      const titleEl = q('visitHistoryTitle');
+      const { open, elderId, page, pageSize } = visitHistoryModalState;
+
+      if (!overlay){
+        return;
+      }
+
+      if (!open || !elderId){
+        overlay.classList.remove('open');
+        overlay.setAttribute('aria-hidden', 'true');
+        if (body) body.innerHTML = '';
+        if (pageEl) pageEl.textContent = '';
+        if (prevBtn) prevBtn.disabled = true;
+        if (nextBtn) nextBtn.disabled = true;
+        return;
+      }
+
+      overlay.classList.add('open');
+      overlay.setAttribute('aria-hidden', 'false');
+
+      const elder = elders.get(elderId);
+      if (titleEl){
+        const displayName = elder ? [elder.preferredName, elder.lastName].filter(Boolean).join(' ').trim() : '';
+        titleEl.textContent = displayName ? `Visit history · ${displayName}` : 'Visit history';
+      }
+
+      const allVisits = getVisitsForElder(elderId);
+      const total = allVisits.length;
+      const totalPages = Math.max(1, Math.ceil(Math.max(total, 1) / pageSize));
+      const clampedPage = Math.min(page, totalPages - 1);
+      if (clampedPage !== page) visitHistoryModalState.page = clampedPage;
+      const start = clampedPage * pageSize;
+      const pageVisits = allVisits.slice(start, start + pageSize);
+
+      if (body){
+        if (!pageVisits.length){
+          body.innerHTML = '<div class="history-modal-empty">No visit history recorded yet.</div>';
+        } else {
+          const itemsHtml = pageVisits.map(v=> renderHistoryItem(v, 'history-modal-item')).join('');
+          body.innerHTML = `<ul class="history-modal-list">${itemsHtml}</ul>`;
+        }
+      }
+
+      const showingTo = Math.min(start + pageVisits.length, total);
+      if (pageEl){
+        pageEl.textContent = total ? `Showing ${start + 1}–${showingTo} of ${total}` : 'No visits yet';
+      }
+      if (prevBtn) prevBtn.disabled = clampedPage <= 0 || !total;
+      if (nextBtn) nextBtn.disabled = clampedPage >= totalPages - 1 || !total;
+
+      const modalEl = overlay.querySelector('.modal');
+      if (modalEl && document.activeElement === overlay){
+        modalEl.focus();
+      }
+    }
+
+    window.toggleHistoryPanel = (elderId)=>{
+      if (!elderId) return;
+      if (expandedHistoryPanels.has(elderId)) expandedHistoryPanels.delete(elderId);
+      else expandedHistoryPanels.add(elderId);
+      renderElders();
+    };
+    window.openVisitHistoryModal = (elderId)=>{
+      if (!elderId) return;
+      visitHistoryModalState.elderId = elderId;
+      visitHistoryModalState.page = 0;
+      visitHistoryModalState.open = true;
+      visitHistoryLastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      renderVisitHistoryModal();
+      const modalEl = q('visitHistoryOverlay')?.querySelector('.modal');
+      if (modalEl){
+        setTimeout(()=> modalEl.focus(), 0);
+      }
+    };
+    window.closeVisitHistoryModal = ()=>{
+      if (!visitHistoryModalState.open) return;
+      visitHistoryModalState.open = false;
+      renderVisitHistoryModal();
+      const focusTarget = visitHistoryLastFocus;
+      visitHistoryLastFocus = null;
+      if (focusTarget && typeof focusTarget.focus === 'function'){
+        setTimeout(()=> focusTarget.focus(), 0);
+      }
+    };
+    window.changeVisitHistoryPage = (delta)=>{
+      if (!visitHistoryModalState.open || !visitHistoryModalState.elderId) return;
+      const total = getVisitsForElder(visitHistoryModalState.elderId).length;
+      const totalPages = Math.max(1, Math.ceil(Math.max(total, 1) / visitHistoryModalState.pageSize));
+      const nextPage = Math.min(totalPages - 1, Math.max(0, visitHistoryModalState.page + (Number(delta)||0)));
+      if (nextPage !== visitHistoryModalState.page){
+        visitHistoryModalState.page = nextPage;
+        renderVisitHistoryModal();
+      }
+    };
+    const visitHistoryOverlayEl = q('visitHistoryOverlay');
+    visitHistoryOverlayEl?.addEventListener('click', (event)=>{
+      if (event.target === visitHistoryOverlayEl) closeVisitHistoryModal();
+    });
+    visitHistoryOverlayEl?.addEventListener('keydown', (event)=>{
+      if (!visitHistoryModalState.open) return;
+      if (event.key === 'Escape'){
+        event.preventDefault();
+        closeVisitHistoryModal();
+      } else if (event.key === 'Tab'){
+        const focusables = Array.from(visitHistoryOverlayEl.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'))
+          .filter(el => !el.disabled && el.offsetParent !== null);
+        if (!focusables.length) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (event.shiftKey && document.activeElement === first){
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last){
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    });
 
     /* ---------- Actions ---------- */
     window.textAndTrack = runAction(async (elderId)=>{


### PR DESCRIPTION
## Summary
- add a visit history range filter and expandable preview panel to each elder row
- surface a paginated visit history modal that can be opened on demand
- extend styling and helper utilities to support the new directory history experience

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68f7d4575eb08326a5599e63ef7fc4ed